### PR TITLE
ASA-4900: Fix for the IRX_MINOR_CACHE_HOME flag

### DIFF
--- a/src/main/java/com/hcl/appscan/maven/plugin/IMavenConstants.java
+++ b/src/main/java/com/hcl/appscan/maven/plugin/IMavenConstants.java
@@ -35,5 +35,6 @@ public interface IMavenConstants {
 	String VAR_JAVA_HOME					= "JAVA_HOME";										//$NON-NLS-1$
 	String PROP_JAVA_HOME					= "java.home";										//$NON-NLS-1$
 	String JSP_COMPILER						= "jspCompiler";									//$NON-NLS-1$
+	String IRX_MINOR_CACHE_HOME				= "irx_minor_cache_home";							//$NON-NLS-1$
 	String NAMESPACES						= "namespaces"; 									//$NON-NLS-1$
 }

--- a/src/main/java/com/hcl/appscan/maven/plugin/targets/MavenJavaTarget.java
+++ b/src/main/java/com/hcl/appscan/maven/plugin/targets/MavenJavaTarget.java
@@ -9,6 +9,7 @@ package com.hcl.appscan.maven.plugin.targets;
 import java.io.File;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import org.apache.maven.artifact.Artifact;
@@ -57,7 +58,20 @@ public class MavenJavaTarget extends JavaTarget implements IMavenConstants{
 	
 	@Override
 	public Map<String, String> getProperties() {
+		String irx_cache_path = "";
 		Map<String, String> buildInfos = super.getProperties();
+		
+		if (System.getProperty(IRX_MINOR_CACHE_HOME.toUpperCase()) != null)
+			irx_cache_path = System.getProperty(IRX_MINOR_CACHE_HOME.toUpperCase());
+		else if (System.getProperty(IRX_MINOR_CACHE_HOME) != null)
+			irx_cache_path = System.getProperty(IRX_MINOR_CACHE_HOME);
+		
+		if (irx_cache_path != "") {
+			File cache_dir = new File(irx_cache_path);
+			cache_dir.mkdir();
+			buildInfos.put(IRX_MINOR_CACHE_HOME, irx_cache_path);
+		}
+		
 		buildInfos.put("package_includes", getNamespaces());
 		return buildInfos;
 	}


### PR DESCRIPTION
Fix for IRX_MINOR_CACHE_HOME not being honored via the mvn command line. This flag is now set in the appscan-config.xml during every scan (if specified) and will be used by CLI to determine the user-specified irx cache location.