### PR TITLE
fix outputDirectory support for child modules

### DIFF
--- a/src/main/java/com/hcl/appscan/maven/plugin/targets/MavenJavaTarget.java
+++ b/src/main/java/com/hcl/appscan/maven/plugin/targets/MavenJavaTarget.java
@@ -54,8 +54,12 @@ public class MavenJavaTarget extends JavaTarget implements IMavenConstants{
 			finalName = m_project.getBuild().getFinalName();
 		
 		String outputDirectory = MavenUtil.getPluginConfigurationProperty(m_project, JAR_KEY, OUTPUT_DIRECTORY);
-		if(outputDirectory == null)
+		if(outputDirectory != null) {
+			outputDirectory = new File(m_project.getBasedir(), outputDirectory).getAbsolutePath();
+		}
+		else {
 			outputDirectory = m_project.getBuild().getDirectory();
+		}
 		
 		return new File(outputDirectory, finalName + JAR_EXTENSION);
 	}


### PR DESCRIPTION
Fix handling of the outputDirectory property so it's relative to the project directory. This is not currently working for submodules.
